### PR TITLE
Vive Controller Pointers

### DIFF
--- a/include/cnovropenvr.h
+++ b/include/cnovropenvr.h
@@ -25,6 +25,7 @@ S_API bool VR_IsInterfaceVersionValid(const char *pchInterfaceVersion);
 void * CNOVRGetOpenVRFunctionTable( const char * interfacename );
 void CNOVRPoseFromHMDMatrix( cnovr_pose * pose, struct HmdMatrix34_t * matrix ); 
 char * CNOVRGetTrackedDeviceString( TrackedDeviceIndex_t unDevice, TrackedDeviceProperty prop );
+int32_t CNOVRGetTrackedDeviceInt32(TrackedDeviceIndex_t unDevice, TrackedDeviceProperty property);
 
 #endif
 

--- a/include/cnovropenvr.h
+++ b/include/cnovropenvr.h
@@ -26,6 +26,7 @@ void * CNOVRGetOpenVRFunctionTable( const char * interfacename );
 void CNOVRPoseFromHMDMatrix( cnovr_pose * pose, struct HmdMatrix34_t * matrix ); 
 char * CNOVRGetTrackedDeviceString( TrackedDeviceIndex_t unDevice, TrackedDeviceProperty prop );
 int32_t CNOVRGetTrackedDeviceInt32(TrackedDeviceIndex_t unDevice, TrackedDeviceProperty property);
+int32_t CNOVRGetControllerHandFromDeviceID(TrackedDeviceIndex_t unDevice);
 
 #endif
 

--- a/modules/openvrobjects/openvrobjects.c
+++ b/modules/openvrobjects/openvrobjects.c
@@ -102,6 +102,7 @@ int ObjFocusEvent( int event, cnovrfocus_capture * cap, cnovrfocus_properties * 
 void OpenVRObjectsUpdateFunction( void * tag, void * opaquev )
 {
 	int i;
+	int j = 1;	//byteshift variable for vive controllers
 	for( i = 0; i < MAXRNS; i++ )
 	{
 		// o->trackedDeviceIndex
@@ -141,7 +142,12 @@ void OpenVRObjectsUpdateFunction( void * tag, void * opaquev )
 			capture->cb = ObjFocusEvent;
 			CNOVRModelSetInteractable( rp->modelsimple, capture );
 			if( strstr( rmname, "controller" ) )
-				rp->modelsimple->focuscontrol->collide_mask = (strstr( rmname, "left" )?2:0) | (strstr( rmname, "right" )?4:0);
+			{
+				if(strstr( rmname, "vive" )?1:0)	//if we are using a vive, left and right doesn't exist
+					rp->modelsimple->focuscontrol->collide_mask = j <<= 1;	//byteshifting to get 2 and 4 for the mask
+				else
+					rp->modelsimple->focuscontrol->collide_mask = (strstr( rmname, "left" )?2:0) | (strstr( rmname, "right" )?4:0);
+			}
 		}
 	}
 	

--- a/modules/openvrobjects/openvrobjects.c
+++ b/modules/openvrobjects/openvrobjects.c
@@ -102,7 +102,6 @@ int ObjFocusEvent( int event, cnovrfocus_capture * cap, cnovrfocus_properties * 
 void OpenVRObjectsUpdateFunction( void * tag, void * opaquev )
 {
 	int i;
-	int j = 2;	//variable for vive controllers
 	for( i = 0; i < MAXRNS; i++ )
 	{
 		// o->trackedDeviceIndex
@@ -145,8 +144,10 @@ void OpenVRObjectsUpdateFunction( void * tag, void * opaquev )
 			{
 				if( strstr( rmname, "vive" ) )	//if we are using a vive, left and right doesn't exist
 				{
-					rp->modelsimple->focuscontrol->collide_mask = j;
-					j = (j > 2?2:4);	//each time we go through this loop, cycle between 2 and 4
+					int32_t ControllerRole = CNOVRGetControllerHandFromDeviceID(i);
+					printf("Controller role of device ID %i is %ld.\n", i, ControllerRole);
+
+					rp->modelsimple->focuscontrol->collide_mask = ControllerRole * 2;
 				}
 				else
 				{

--- a/modules/openvrobjects/openvrobjects.c
+++ b/modules/openvrobjects/openvrobjects.c
@@ -142,12 +142,12 @@ void OpenVRObjectsUpdateFunction( void * tag, void * opaquev )
 			CNOVRModelSetInteractable( rp->modelsimple, capture );
 			if( strstr( rmname, "controller" ) )
 			{
-				if( strstr( rmname, "vive" ) )	//if we are using a vive, left and right doesn't exist
+				if( strstr( rmname, "vive" ) )
 				{
 					int32_t ControllerRole = CNOVRGetControllerHandFromDeviceID(i);
 					printf("Controller role of device ID %i is %ld.\n", i, ControllerRole);
 
-					rp->modelsimple->focuscontrol->collide_mask = ControllerRole * 2;
+					rp->modelsimple->focuscontrol->collide_mask = ControllerRole * 2; // TODO: See if this can be generalized to both Index and Vive controllers.
 				}
 				else
 				{

--- a/modules/openvrobjects/openvrobjects.c
+++ b/modules/openvrobjects/openvrobjects.c
@@ -144,9 +144,13 @@ void OpenVRObjectsUpdateFunction( void * tag, void * opaquev )
 			if( strstr( rmname, "controller" ) )
 			{
 				if(strstr( rmname, "vive" )?1:0)	//if we are using a vive, left and right doesn't exist
+				{
 					rp->modelsimple->focuscontrol->collide_mask = j <<= 1;	//byteshifting to get 2 and 4 for the mask
+				}
 				else
+				{
 					rp->modelsimple->focuscontrol->collide_mask = (strstr( rmname, "left" )?2:0) | (strstr( rmname, "right" )?4:0);
+				}
 			}
 		}
 	}

--- a/modules/openvrobjects/openvrobjects.c
+++ b/modules/openvrobjects/openvrobjects.c
@@ -102,7 +102,7 @@ int ObjFocusEvent( int event, cnovrfocus_capture * cap, cnovrfocus_properties * 
 void OpenVRObjectsUpdateFunction( void * tag, void * opaquev )
 {
 	int i;
-	int j = 1;	//byteshift variable for vive controllers
+	int j = 2;	//variable for vive controllers
 	for( i = 0; i < MAXRNS; i++ )
 	{
 		// o->trackedDeviceIndex
@@ -143,9 +143,10 @@ void OpenVRObjectsUpdateFunction( void * tag, void * opaquev )
 			CNOVRModelSetInteractable( rp->modelsimple, capture );
 			if( strstr( rmname, "controller" ) )
 			{
-				if(strstr( rmname, "vive" )?1:0)	//if we are using a vive, left and right doesn't exist
+				if( strstr( rmname, "vive" ) )	//if we are using a vive, left and right doesn't exist
 				{
-					rp->modelsimple->focuscontrol->collide_mask = j <<= 1;	//byteshifting to get 2 and 4 for the mask
+					rp->modelsimple->focuscontrol->collide_mask = j;
+					j = (j > 2?2:4);	//each time we go through this loop, cycle between 2 and 4
 				}
 				else
 				{

--- a/modules/openvrobjects/openvrobjects.c
+++ b/modules/openvrobjects/openvrobjects.c
@@ -155,6 +155,11 @@ void OpenVRObjectsUpdateFunction( void * tag, void * opaquev )
 				}
 			}
 		}
+		if(cnovrstate->bRenderPosesValid[i] && rp->loaded && CNOVRGetTrackedDeviceInt32(i, ETrackedDeviceProperty_Prop_DeviceClass_Int32) == ETrackedDeviceClass_TrackedDeviceClass_Controller)
+		{ // TODO: Don't stupidly check this every frame, instead listen for change events.
+			int32_t ControllerRole = CNOVRGetControllerHandFromDeviceID(i);
+			rp->modelsimple->focuscontrol->collide_mask = ControllerRole * 2;
+		}
 	}
 	
 	for( i = 0; i < MAXRNS; i++ )

--- a/src/cnovropenvr.c
+++ b/src/cnovropenvr.c
@@ -70,10 +70,14 @@ int32_t CNOVRGetTrackedDeviceInt32(TrackedDeviceIndex_t unDevice, TrackedDeviceP
 	TrackedPropertyError RetrievalError;
 	Output = cnovrstate->oSystem->GetInt32TrackedDeviceProperty(unDevice, property, &RetrievalError);
 
-	printf("Getting property %i of device %i returned a value of %i with error %i.", property, unDevice, Output, RetrievalError);
-
 	if(RetrievalError) { ovrprintf("Error getting tracked device int32 property %d:%d:%d\n", unDevice, property, RetrievalError); }
 	return Output;
 }
 
-
+// Given a tracked device ID of a controller, this will tell you which hand it is associated with.
+// 0 = Invalid, 1 = Left Hand, 2 = Right Hand
+int32_t CNOVRGetControllerHandFromDeviceID(TrackedDeviceIndex_t unDevice)
+{
+	if( !cnovrstate->oSystem ) return 0;
+	return cnovrstate->oSystem->GetControllerRoleForTrackedDeviceIndex(unDevice);
+}

--- a/src/cnovropenvr.c
+++ b/src/cnovropenvr.c
@@ -53,9 +53,27 @@ char * CNOVRGetTrackedDeviceString( TrackedDeviceIndex_t unDevice, TrackedDevice
 	if( e ) goto err;
 	return t->data;
 err:
-	ovrprintf( "Error getting tracked device property %d:%d:%d\n", unDevice, prop, e );
+	ovrprintf( "Error getting tracked device string property %d:%d:%d\n", unDevice, prop, e );
 	t->data[0] = 0;
 	return t->data; 
+}
+
+// Gets an int32 property of the given device from the OpenVR system.
+// unDevice: The device to get data about
+// property: The data to get about the device. See ETrackedDeviceProperty in the OpenVR API for the list of options.
+int32_t CNOVRGetTrackedDeviceInt32(TrackedDeviceIndex_t unDevice, TrackedDeviceProperty property)
+{
+	int32_t Output = 0;
+
+	if( !cnovrstate->oSystem ) return 0;
+ 
+	TrackedPropertyError RetrievalError;
+	Output = cnovrstate->oSystem->GetInt32TrackedDeviceProperty(unDevice, property, &RetrievalError);
+
+	printf("Getting property %i of device %i returned a value of %i with error %i.", property, unDevice, Output, RetrievalError);
+
+	if(RetrievalError) { ovrprintf("Error getting tracked device int32 property %d:%d:%d\n", unDevice, property, RetrievalError); }
+	return Output;
 }
 
 

--- a/src/cnovrtccinterface.c
+++ b/src/cnovrtccinterface.c
@@ -701,6 +701,7 @@ const struct ImportList ILSYMS[] = {
 	TCCExportS( CNOVRFocusGetVRActionHandleFromConrollerAndCtrlA )
 	TCCExportS( CNOVRGetTrackedDeviceString )
 	TCCExportS( CNOVRGetTrackedDeviceInt32 )
+	TCCExportS( CNOVRGetControllerHandFromDeviceID )
 	TCCExportS( CNOVRListCall )
 	TCCExportS( CNOVRFBufferActivate )
 	TCCExportS( CNOVRFBufferBlitResolve )

--- a/src/cnovrtccinterface.c
+++ b/src/cnovrtccinterface.c
@@ -700,6 +700,7 @@ const struct ImportList ILSYMS[] = {
 	TCCExport( CNOVRRFBufferCreate )
 	TCCExportS( CNOVRFocusGetVRActionHandleFromConrollerAndCtrlA )
 	TCCExportS( CNOVRGetTrackedDeviceString )
+	TCCExportS( CNOVRGetTrackedDeviceInt32 )
 	TCCExportS( CNOVRListCall )
 	TCCExportS( CNOVRFBufferActivate )
 	TCCExportS( CNOVRFBufferBlitResolve )


### PR DESCRIPTION
> No, really, I am going to keep treating this like a little pile of garbage... and if it catches fire, I'll probably throw some extra fuel on it and watch it burn for a bit.  Come round the campfire, friends.  Submit your broken PRs @WORMSTweaker .  Submit broken code to master. It's all good.
> \- @cnlohr 2020-02-27

We took your advice to heart and present: a very inefficient kind-of solution. You can probably put more blame on me for this one.

Note, right now you are checking whether a Index controller is left or right by actually reading it's device name. Theoretically, this can also be replaced by my new `CNOVRGetControllerHandFromDeviceID()` method, which is theoretically more performant, but since neither of us have an Index to test, we held off on making this change.

Changes made:
- Fixed Vive controllers' pointer rays not working due to self-collision.
- Fixed info window constantly being open over Vive controller due to self-collision.
- Now seems to handle any sequence of controllers turning on / losing tracking / gaining tracking / getting assigned a hand, during runtime, smoothly. Previously, both controllers needed to be on and tracking at startup.
- Vive controllers are now checked for which hand they are in every single update. This should be replaced with listening to OpenVR events for changes, but that is beyond my C capabilities. From what I can tell though, it shouldn't be a serious performance impact.
- Added `CNOVRGetControllerHandFromDeviceID()` which gives you info about whether the given device ID is in the left hand, right hand, or invalid (not yet determined, or not a controller). Tested on Vive controllers, not Index or others.
- Added `CNOVRGetTrackedDeviceInt32()` because there's a ton of useful info you can get out of OpenVR that isn't a string. We didn't end up needing it (as it turns out `ETrackedDeviceProperty_Prop_ControllerRoleHint_Int32` is deprecated), but it can totally be useful for other tasks, and I tested it and am fairy confident that it works OK.
- Probably broke stuff. Sorry.